### PR TITLE
@enter foo(20) -> ASTInterpreter2.@enter foo(20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ function foo(n)
     ((BigInt[1 1; 1 0])^x)[2,1]
 end
 
-@enter foo(20)
+ASTInterpreter2.@enter foo(20)
 ```
 
 Basic Commands:


### PR DESCRIPTION
Because Juno also exports `@enter` and hence it will be better to be unambiguous. I got this error when I run this from Juon, if I don't specify `ASTInterpreter2` e.g. `@enter foo(20)` gives

> WARNING: both ASTInterpreter2 and Juno export "@enter"; uses of it in module Main must be qualified
> ERROR: LoadError: UndefVarError: @enter not defined