### PR TITLE
Fix calls to kwfuncs

### DIFF
--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -99,3 +99,6 @@ function fbc()
 end
 @test @interpret(fbc()) == fbc()
 @test @interpret(repr("hi")) == repr("hi")  # this tests kwargs and @generated functions
+
+fkw(x::Int8; y=0, z="hello") = y
+@test @interpret(fkw(Int8(1); y=22, z="world")) == fkw(Int8(1); y=22, z="world")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,11 @@ using REPL
 
 using DebuggerFramework
 
-include("utils.jl")
-include("evaling.jl")
-include("stepping.jl")
-include("interpret.jl")
+@testset "Main tests" begin
+    include("utils.jl")
+    include("evaling.jl")
+    include("stepping.jl")
+    include("interpret.jl")
+    include("misc.jl")
+end
 include("ui.jl")
-include("misc.jl")

--- a/test/stepping.jl
+++ b/test/stepping.jl
@@ -199,3 +199,13 @@ try
 catch e
     @assert isa(e, ErrorException)
 end
+
+# Issue #17
+struct B{T} end
+function (::B)(y)
+    x = 42*y
+    return x + y
+end
+
+B_inst = B{Int}()
+step_through(ASTInterpreter2.enter_call_expr(:($(B_inst)(10))))


### PR DESCRIPTION
I *thought* we'd had adequate test coverage of keyword functions, but it turns out I was mistaken. This should fix them for real.

Also adds the test from #35 (which was already working on master).

It turns out I still don't have merge privileges here.